### PR TITLE
keep debugging

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -12,7 +12,7 @@ function susieGLM(L::Int64,Π::Vector{Float64},y::Vector{Float64},X::Matrix{Floa
         X₀ = hcat(ones(n),X₀)
     end
          
-    y1[:] =y.-0.5 # centered y
+    y1 =y.-0.5 # centered y
 #initialization :
  σ0 = ones(L);
 #  β = rand(c)/sqrt(c)

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -157,6 +157,7 @@ function postB!(A1::Matrix{Float64}, B1::Matrix{Float64}, Sig1::Matrix{Float64},
                 # Z0= y - λ.*(getXy('N',X₀,β) + getXy('N',X,sum(hcat(AB1[:,1:l-1],AB0[:,l+1:end]),dims=2)[:,1]))
                 Z0= (y - λ.*(getXy('N',X₀,β) + getXy('N',X,sum(dropCol(AB0,l),dims=2)[:,1])))
                 Z =  getXy('T',X,Z0)
+                writedlm(homedir()*"/GIT/SuSiEGLMM.jl/testdata/nums-julia.txt",Z)
                 B1[:,l] = Diagonal(Sig1[:,l])*Z #posterior bₗ
                   # compute α_1
                 # A0[:,l] = Π.*exp.(Z./(1.0.+ϕ/σ0[l]))./sqrt.(σ0[l]*ϕ.^(-1).+1)

--- a/src/test1.R
+++ b/src/test1.R
@@ -8,7 +8,7 @@ L = 1
 V = 1
 beta_true = rep(0, p)
 
-B = 100
+B = 1
 b_1s = numeric(B)
 susie.fits.easy = list() # logistic SuSiE fits
 logistic.fits.easy = list() # logistic regression fits

--- a/src/test1.R
+++ b/src/test1.R
@@ -1,4 +1,6 @@
+source("test/logistic_susie_VB_functions.R")
 set.seed(1138)
+
 
 n = 100
 p = 10
@@ -15,8 +17,12 @@ for (i in 1:B) {
   b_1s[i] = beta_true[1]
   # make independent N(0, 1) covariates
   X = matrix(rnorm(n * p), nrow = n)
+  filename=paste("testdata/dataX",i,".csv",sep="")
+  write.csv(X,filename)
   # make response
   Y = rbinom(n, 1, exp(X %*% beta_true) / (1 + exp(X %*% beta_true)))
+  filename1=paste("testdata/dataY",i,".csv",sep="")
+  write.csv(Y,filename1)
   susie.fits.easy[[i]] = susie_logistic_VB(Y, X, L, V)
   logistic.fits.easy[[i]] = glm(Y ~ X, family = "binomial")
 }

--- a/test/glm_test.jl
+++ b/test/glm_test.jl
@@ -68,28 +68,54 @@ md"
 begin 
 	
 
-# n=100; p=10; 
+# # n=100; p=10; 
 # L=1;
-b_true=zeros(p);
-# B=100;
-b_1s=zeros(B); res=[];
-for j = 1:B
+# b_true=zeros(p);
+# # B=100;
+# b_1s=zeros(B); res=[];
+# for j = 1:B
 
-    b_true[1]= randn(1)[1] 
-    b_1s[j] = b_true[1]
-    X=randn(n,p)
-    Y= logistic.(X*b_true) .<rand(n) #generating binary outcome
-    Y=convert(Vector{Float64},Y)
-    res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-4) 
-    res=[res;res0]
-end
+#     b_true[1]= randn(1)[1] 
+#     b_1s[j] = b_true[1]
+#     X=randn(n,p)
+#     Y= logistic.(X*b_true) .<rand(n) #generating binary outcome
+
+# 	Y=convert(Vector{Float64},Y)
+#     res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-4) 
+#     res=[res;res0]
+# end
+
+X=readdlm("../testdata/dataX.csv",',';skipstart=1)[:,2:end];
+Y=readdlm("../testdata/dataY.csv",',';skipstart=1)[:,end]
+
+res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
+
+
+	
 end;
 
+# ╔═╡ 7fb9a3f7-424b-4bab-91cf-cba1517c2767
+b_1s
+
 # ╔═╡ 7ed716f7-2887-405a-9cee-f9f503e53af2
-b̂ = [res[j].α[1]*res[j].ν[1] for j=1:B]
+# b̂ = [res[j].α[1]*res[j].ν[1] for j=1:B]
+b̂ = res0.ν
 
 # ╔═╡ 8e5a2b03-e081-4218-93e3-6ebb8532befe
-α̂ = [res[j].α[1] for j=1:B]
+# α̂ = [res[j].α[1] for j=1:B]
+α̂ =res0.α
+
+# ╔═╡ a06b16d3-6342-47a0-a835-f9832b957d7b
+res0.Σ
+
+# ╔═╡ 2c1c9351-0529-46d8-8013-70d405d8d723
+res0.β
+
+# ╔═╡ 58fb9b8d-bd94-4267-a12a-306b7df254bf
+res0.ξ
+
+# ╔═╡ 5e146eaf-b515-424f-9bde-9c9b62a2d80f
+res0.elbo
 
 # ╔═╡ f7c0d83e-d001-497f-8622-9fdcea9e0f50
 scatterplot(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate")
@@ -600,11 +626,16 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 # ╟─d6b57884-d5d5-4165-b384-d85f3c95d310
 # ╟─fe5f4aff-600f-4bd2-aecf-d15e0ad1a736
 # ╟─21313e12-c0cb-4b39-aae3-9cc065a7af2a
-# ╟─9352441a-20c0-4594-bde5-96c3fbf45541
+# ╠═9352441a-20c0-4594-bde5-96c3fbf45541
 # ╟─774a0988-a3e5-4d48-8ba3-9fccc55753d8
 # ╠═111151f8-7d15-47aa-8330-361fd0403866
+# ╠═7fb9a3f7-424b-4bab-91cf-cba1517c2767
 # ╠═7ed716f7-2887-405a-9cee-f9f503e53af2
 # ╠═8e5a2b03-e081-4218-93e3-6ebb8532befe
+# ╠═a06b16d3-6342-47a0-a835-f9832b957d7b
+# ╠═2c1c9351-0529-46d8-8013-70d405d8d723
+# ╠═58fb9b8d-bd94-4267-a12a-306b7df254bf
+# ╠═5e146eaf-b515-424f-9bde-9c9b62a2d80f
 # ╠═f7c0d83e-d001-497f-8622-9fdcea9e0f50
 # ╠═1bcbef2f-f5cc-4495-8d7b-54c6ca82ae47
 # ╠═6cfbe9be-7269-477f-bfe9-c102b716984b

--- a/test/glm_test.jl
+++ b/test/glm_test.jl
@@ -46,7 +46,7 @@ $(@bind p NumberField(10:100, default=10))
 
 
 B: 
-$(@bind B Slider(100:1000))
+$(@bind B Slider(1:100))
 
 "
 
@@ -54,7 +54,7 @@ $(@bind B Slider(100:1000))
 n, B
 
 # ╔═╡ 9352441a-20c0-4594-bde5-96c3fbf45541
-Random.seed!(1138);
+Random.seed!(138);
 
 # ╔═╡ 774a0988-a3e5-4d48-8ba3-9fccc55753d8
 md"
@@ -64,46 +64,61 @@ md"
 #### L=1
 "
 
+# ╔═╡ b97e0c7e-1703-4b7f-8814-4d0fac5d1d91
+pwd()
+
 # ╔═╡ 111151f8-7d15-47aa-8330-361fd0403866
 begin 
 	
 
-# # n=100; p=10; 
+# n=100; p=10; 
 # L=1;
-# b_true=zeros(p);
-# # B=100;
-# b_1s=zeros(B); res=[];
-# for j = 1:B
+b_true=zeros(p);
+# B=100;
+b_1s=zeros(B); res=[];
+for j = 1:B
 
-#     b_true[1]= randn(1)[1] 
-#     b_1s[j] = b_true[1]
-#     X=randn(n,p)
-#     Y= logistic.(X*b_true) .<rand(n) #generating binary outcome
+    b_true[1]= randn(1)[1] 
+    b_1s[j] = b_true[1]
+    X=randn(n,p)
+    Y= logistic.(X*b_true) .<rand(n) #generating binary outcome
 
-# 	Y=convert(Vector{Float64},Y)
-#     res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-4) 
-#     res=[res;res0]
-# end
+	Y=convert(Vector{Float64},Y)
+    res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-4) 
+    res=[res;res0]
+end
 
-X=readdlm("../testdata/dataX.csv",',';skipstart=1)[:,2:end];
-Y=readdlm("../testdata/dataY.csv",',';skipstart=1)[:,end]
+# X=readdlm("../testdata/dataX1.csv",',';skipstart=1)[:,2:end];
+# Y=readdlm("../testdata/dataY1.csv",',';skipstart=1)[:,end]
 
-res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
+# res0= susieGLM(1, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
 
 
 	
 end;
 
-# ╔═╡ 7fb9a3f7-424b-4bab-91cf-cba1517c2767
-b_1s
+# ╔═╡ 82ebaab3-9a24-4af8-81b7-8f69f929a691
+
 
 # ╔═╡ 7ed716f7-2887-405a-9cee-f9f503e53af2
-# b̂ = [res[j].α[1]*res[j].ν[1] for j=1:B]
-b̂ = res0.ν
+b̂ = [res[j].α[1]*res[j].ν[1] for j=1:B]
+# b̂ = res0.ν
+
+# ╔═╡ da9f4384-fcd8-4ee6-8e2f-521e9ad2f101
+res[1].α[1]
+
+# ╔═╡ fabbf0a6-1b95-4f2b-869d-f43cf34f77c6
+res[1].ν[1]
+
+# ╔═╡ ca50fd67-f99d-49a8-9206-6cfa1f0703d7
+b_1s[1]
+
+# ╔═╡ 274a298e-e076-44c2-8c5b-5b0736c12c48
+b_1s
 
 # ╔═╡ 8e5a2b03-e081-4218-93e3-6ebb8532befe
-# α̂ = [res[j].α[1] for j=1:B]
-α̂ =res0.α
+α̂ = [res[j].α[1] for j=1:B]
+# α̂ =res0.α
 
 # ╔═╡ a06b16d3-6342-47a0-a835-f9832b957d7b
 res0.Σ
@@ -117,15 +132,21 @@ res0.ξ
 # ╔═╡ 5e146eaf-b515-424f-9bde-9c9b62a2d80f
 res0.elbo
 
+# ╔═╡ 6bb5497e-6bf7-4945-bae0-e2d1ac4c8452
+(n,p,B)
+
 # ╔═╡ f7c0d83e-d001-497f-8622-9fdcea9e0f50
 scatterplot(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate")
+
+
+# ╔═╡ 5aa4bea9-ba24-4be4-8d27-41cecf63c944
 
 
 # ╔═╡ 1bcbef2f-f5cc-4495-8d7b-54c6ca82ae47
 scatterplot(b_1s,α̂, xlabel="True effects",ylabel="PIP")
 
 # ╔═╡ 6cfbe9be-7269-477f-bfe9-c102b716984b
-[b̂[end-2] b_1s[end-2] res[end-2].elbo]
+[b̂l[end-2] b_1s[end-2] res1[end-2].elbo]
 
 # ╔═╡ 64aa8bfa-b72c-40fd-a911-986a953899b7
 md"
@@ -133,30 +154,30 @@ md"
 "
 
 # ╔═╡ 5f70ae45-6734-4dc1-980c-cee3624f52cb
-begin
+# begin
 
-# L=2;
-B_true=zeros(p);
-# B=100;
-B_1s=zeros(B); res1=[];
-B_2s=zeros(B)
-for j = 1:B
+# # L=2;
+# B_true=zeros(p);
+# # B=100;
+# B_1s=zeros(B); res1=[];
+# B_2s=zeros(B)
+# for j = 1:B
 
-    B_true[1]= randn(1)[1] 
-	B_true[2]= randn(1)[1]
-    B_1s[j] = B_true[1]
-	B_2s[j] = B_true[2]
-    X=randn(n,p)
-    Y= logistic.(X*B_true) .<rand(n) #generating binary outcome
-    Y=convert(Vector{Float64},Y)
-    res00= susieGLM(2, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
-    res1=[res1;res00]
-end
-
-
+#     B_true[1]= randn(1)[1] 
+# 	B_true[2]= randn(1)[1]
+#     B_1s[j] = B_true[1]
+# 	B_2s[j] = B_true[2]
+#     X=randn(n,p)
+#     Y= logistic.(X*B_true) .<rand(n) #generating binary outcome
+#     Y=convert(Vector{Float64},Y)
+#     res00= susieGLM(2, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
+#     res1=[res1;res00]
+# end
 
 
-end;
+
+
+# end;
 
 # ╔═╡ 9d8a159e-de52-4cb0-8c52-8252c447b76d
 begin
@@ -625,18 +646,25 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 # ╠═4eddfd44-06ae-46c4-8dd9-d843ca70619e
 # ╟─d6b57884-d5d5-4165-b384-d85f3c95d310
 # ╟─fe5f4aff-600f-4bd2-aecf-d15e0ad1a736
-# ╟─21313e12-c0cb-4b39-aae3-9cc065a7af2a
+# ╠═21313e12-c0cb-4b39-aae3-9cc065a7af2a
 # ╠═9352441a-20c0-4594-bde5-96c3fbf45541
 # ╟─774a0988-a3e5-4d48-8ba3-9fccc55753d8
+# ╠═b97e0c7e-1703-4b7f-8814-4d0fac5d1d91
 # ╠═111151f8-7d15-47aa-8330-361fd0403866
-# ╠═7fb9a3f7-424b-4bab-91cf-cba1517c2767
+# ╠═82ebaab3-9a24-4af8-81b7-8f69f929a691
 # ╠═7ed716f7-2887-405a-9cee-f9f503e53af2
+# ╠═da9f4384-fcd8-4ee6-8e2f-521e9ad2f101
+# ╠═fabbf0a6-1b95-4f2b-869d-f43cf34f77c6
+# ╠═ca50fd67-f99d-49a8-9206-6cfa1f0703d7
+# ╠═274a298e-e076-44c2-8c5b-5b0736c12c48
 # ╠═8e5a2b03-e081-4218-93e3-6ebb8532befe
 # ╠═a06b16d3-6342-47a0-a835-f9832b957d7b
 # ╠═2c1c9351-0529-46d8-8013-70d405d8d723
 # ╠═58fb9b8d-bd94-4267-a12a-306b7df254bf
 # ╠═5e146eaf-b515-424f-9bde-9c9b62a2d80f
+# ╠═6bb5497e-6bf7-4945-bae0-e2d1ac4c8452
 # ╠═f7c0d83e-d001-497f-8622-9fdcea9e0f50
+# ╠═5aa4bea9-ba24-4be4-8d27-41cecf63c944
 # ╠═1bcbef2f-f5cc-4495-8d7b-54c6ca82ae47
 # ╠═6cfbe9be-7269-477f-bfe9-c102b716984b
 # ╟─64aa8bfa-b72c-40fd-a911-986a953899b7

--- a/test/scratch.jl
+++ b/test/scratch.jl
@@ -138,3 +138,4 @@ b̂ = [res[j].α[1]*res[j].ν[1] for j=1:B]
 using UnicodePlots
 scatterplot(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate")
 scatterplot(b_1s,α̂, xlabel="True effects",ylabel="pip")
+


### PR DESCRIPTION
Generating a dataset from R in Andrew's simulation code to test with julia code does not change the signs of posterior means although the accuracy changes by different seeds.  However,  doing simulation by generating datasets in julia still change the signs.  Also using exact formula from Wakefield 2009 does not resolve this issue.   May try to simplify the exact formula wrt posteriors as Andrew did. Or there may be a term (or terms) acting as a pointer when updating.   Different random number generators between the two softwares should also yield similar pattern in results.  I will try to look at how the norms between consecutive estimates change in convergence criteria.