### PR TITLE
Adjusting initial value for \tau2 & tracking NaN elbo

### DIFF
--- a/src/GLMM.jl
+++ b/src/GLMM.jl
@@ -63,7 +63,7 @@ function initialization(y::Vector{Float64},X::Matrix{Float64},X₀::Union{Matrix
      Xt, Xt₀, yt = rotate(y,X,X₀,T)   
     #  y0= getXy('N',T,y) # rotate w/o centering for β0
     #initialization
-     τ0 = rand(1)[1]; #arbitray
+     τ0 = 0.0001 #rand(1)[1]; #arbitray
     # τ0=1.2   
     β0 = glm(X₀,y,Binomial()) |> coef
     ξ0 =sqrt.(getXy('N',Xt₀,β0).^2+ τ0*S)
@@ -104,7 +104,7 @@ function susieGLMM(L::Int64,Π::Vector{Float64},y::Vector{Float64},X::Matrix{Flo
     Xt, Xt₀, yt = rotate(y,X,X₀,T)   
     # #initialization :
     σ0 = 0.1*ones(L); 
-     τ0 = rand(1)[1]; #arbitray
+     τ0 = 0.0001  #rand(1)[1]; #arbitray
     β0 = glm(X₀,y,Binomial()) |> coef 
     ν0 =sum(repeat(Π,outer=(1,L)).*σ0',dims=2)[:,1] ; #ν²0
     ξ0 =sqrt.(getXy('N',Xt.^2.0,ν0)+ getXy('N',Xt₀,β0).^2+ τ0*S )
@@ -128,8 +128,9 @@ function computeT(init0::Null_est,yt::Vector{Float64},Xt₀::Matrix{Float64},Xt:
         r₀ =  2*yt.*(getXy('N',Xt₀,init0.β)+init0.μ)  
         p̂ = logistic.(r₀)
         Γ  = p̂.*(1.0.-p̂)
-        
+        # XX=Xt₀'Diagonal(Γ)
         proj= I - Xt₀*(symXX('T',sqrt.(Γ).*Xt₀)\(Xt₀'Diagonal(Γ)))
+        # proj = I - Xt₀*(getXX('N',XX,'N',Xt₀))\XX
         G̃ = getXX('N',proj,'N',Xt)
     
         Tstat= zeros(m)


### PR DESCRIPTION
With update on Friday on Slack, a little larger initial value of \tau^2 = 0.001 has more cases that slow down in convergence.  Smaller values than that are faster, yielding very small posterior \tau^2 when converging fast, but very large posterior \tau^2 & the other parameters beta (fixed), \sigma0 (posterior of variance of b's (susie)).  As mentioned on Slack, NaN elbo's are produced for some cases for slow convergence case.  I tracked parameter estimates for the NaN case.  ex. [β_new σ0_new τ2_new]=[-1.8987249551746872e20	1.0739277119811495e10	Inf  ]-> all xi's are very large.  I looked back Andrew's logistic workflow on 'A note on intercept/covariates' :

`In Carbonetto and Stephens (2012) and Carbonetto, Zhou, and Stephens (2017), Peter put a flat prior (normal with large variance) on the effects for the covariates Z (including the intercept, if Z has a column of 1’s). He then integrates out the effects from the likelihood.
 Instead of taking this approach, I have simply included the effects (I refer to them as δ) on the covariates (Z) in the optimization and treat them as nuisance parameters to be optimized over. I suspect these two methods aren’t to different due to the flat prior Peter uses. However, Peter’s method likely takes into account the variability of the estimates for δ.'

I somehow agree with him as we discussed earlier.  I skimmed those papers, and it appears to be worthy of reading them about penalization.  Will keep working on this.  