### PR TITLE
test susie-glm including covariates

### DIFF
--- a/src/GLMM.jl
+++ b/src/GLMM.jl
@@ -104,7 +104,7 @@ function susieGLMM(L::Int64,Π::Vector{Float64},y::Vector{Float64},X::Matrix{Flo
     Xt, Xt₀, yt = rotate(y,X,X₀,T)   
     # #initialization :
     σ0 = 0.1*ones(L); 
-     τ0 = 0.0001  #rand(1)[1]; #arbitray
+     τ0 = 0.001  #rand(1)[1]; #arbitray
     β0 = glm(X₀,y,Binomial()) |> coef 
     ν0 =sum(repeat(Π,outer=(1,L)).*σ0',dims=2)[:,1] ; #ν²0
     ξ0 =sqrt.(getXy('N',Xt.^2.0,ν0)+ getXy('N',Xt₀,β0).^2+ τ0*S )

--- a/test/causal3.jl
+++ b/test/causal3.jl
@@ -162,7 +162,8 @@ Ps=zeros(p,B); Tscore=zeros(B);tt=zeros(p,B);
 # T,S = svdK(K0;LOCO=false)
 # H=svd(K2);
 for j = 1:B
-
+    
+    
     b_true[1]= b_1s[j]
     b_true[2]= b_2s[j]
     b_true[3]= b_3s[j]
@@ -190,7 +191,7 @@ histogram(Ps[3,:],bins=20) #65%
 
 #susie-GLMM
 
-
+X1= (X.-mean(X,dims=2))./std(X,dims=2)
 b_true=zeros(p);
 # b_1s=zeros(B); 
 res1=[]; Tmm=zeros(B)
@@ -198,22 +199,28 @@ res1=[]; Tmm=zeros(B)
 
 for j = 1:B
 
-    # b_true[1]= randn(1)[1] 
-    b_true[1]= b_1s[j]
-    b_true[2]= b_2s[j]
-    b_true[3]= b_3s[j]
+    b_true[1]= randn(1)[1] 
+    b_true[2]=randn(1)[1]
+    b_true[3]=randn(1)[1]
+    b_1s[j] = b_true[1]
+    b_2s[j] = b_true[2]
+    b_3s[j] = b_true[3]
+    
+    # b_true[1]= b_1s[j]
+    # b_true[2]= b_2s[j]
+    # b_true[3]= b_3s[j]
     # X=randn(n,p)
 
     g=rand(MvNormal(τ2*K))
     # writedlm("./testdata/dataX-julia.csv",X)
-    Y= logistic.(X*b_true+g) .>rand(n) #generating binary outcome
+    Y= logistic.(X1*b_true+g) .>rand(n) #generating binary outcome
     Y=convert(Vector{Float64},Y)
     # writedlm("./testdata/dataY-julia.csv",Y)
     # T, S = svdK(K;LOCO=false)
     # Xt, Xt₀, yt, init0 = initialization(Y,X,ones(n,1),T,S;tol=1e-4)     
     # res10 = susieGLMM(L,ones(p)/p,yt,Xt,Xt₀,S,init0;tol=1e-4)
     # @time res10 =susieGLMM(1,ones(p)/p,Y,X1,ones(n,1),T,S) 
-   t0= @elapsed res10=fineQTL_glmm(K,G,Y,X;LOCO=false)
+   t0= @elapsed res10=fineQTL_glmm(K,G,Y,X1;LOCO=false)
     res1=[res1;res10]; Tmm[j]=t0
 end
 

--- a/test/test-covariate_glm.jl
+++ b/test/test-covariate_glm.jl
@@ -1,0 +1,87 @@
+
+using Revise
+
+using Statistics, Distributions, StatsBase, Random, LinearAlgebra, DelimitedFiles, Distributed
+# @everywhere using Pkg
+# @everywher Pkg.activate(homedir()*"/GIT/SuSiEGLMM.jl")
+ using SuSiEGLMM
+
+Seed(124)
+
+n =100;p=10;q=5;
+ L=1; B=100;
+#  τ2=0.4;
+#GLM
+b_true=zeros(p);
+b_1s=zeros(B);
+
+res=[];Tm=zeros(B);
+
+## random covariates
+
+for j = 1:B
+    b_true[1]= randn(1)[1] 
+    b_1s[j] = b_true[1]
+    # b_true[1]=b_1s[j]
+    X=randn(n,p)
+    X₀ = randn(n,q)
+    δ=randn(q)
+    # g=rand(MvNormal(τ2*K)) 
+    Y= logistic.(X*b_true+X₀*δ) .>rand(n) #generating binary outcome
+    Y=convert(Vector{Float64},Y)
+    # writedlm("./testdata/dataY-julia.csv",Y)
+    t0=@elapsed res0= susieGLM(L, ones(p)/p,Y,X,X₀;tol=1e-4) 
+  # t0=@elapsed  res0= fineQTL_glm(G,Y,X;L=L,tol=1e-4)
+    res=[res;res0]; Tm[j]=t0
+end
+
+println("min, median, max times for susie-glm including covariates are $(minimum(Tm)), $(median(Tm)),$(maximum(Tm)).")
+
+b̂=[res[j].α[1]*res[j].ν[1] for j=1:B]
+α̂ = [res[j].α[1] for j=1:B]
+using Plots
+ll=@layout[a;b]; 
+# l2=@layout[a b;c d]
+p1=scatter(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate",label=false,title="SuSiE-GLM+random covariates")
+p2=scatter(b_1s,α̂, xlabel="True effects",ylabel="PIP",label=false)
+plot(p1,p2,layout=ll)
+
+# correlated covariates with predictors
+n =100;p=10;
+ L=1; B=100;
+#  τ2=0.4;
+#GLM
+b_true=zeros(p);
+b_1s=zeros(B);
+
+res1=[];Tm0=zeros(B);
+
+for j = 1:B
+    b_true[1]= randn(1)[1] 
+    b_1s[j] = b_true[1]
+    # b_true[1]=b_1s[j]
+    X=randn(n,p)
+    #correlated covariates
+    X₁ = rand(MvNormal([1 0.9;0.9 1]),n)
+    X[:,1]=X₁[1,:]
+    X₀=convert(Matrix{Float64},X₁[[2],:]')
+    δ=randn(1)
+
+    # g=rand(MvNormal(τ2*K)) 
+    Y= logistic.(X*b_true+X₀*δ) .>rand(n) #generating binary outcome
+    Y=convert(Vector{Float64},Y)
+    # writedlm("./testdata/dataY-julia.csv",Y)
+    t0=@elapsed res0= susieGLM(L, ones(p)/p,Y,X,X₀;tol=1e-4) 
+  # t0=@elapsed  res0= fineQTL_glm(G,Y,X;L=L,tol=1e-4)
+    res1=[res1;res0]; Tm0[j]=t0
+end
+
+println("min, median, max times for susie-glm including covariates are $(minimum(Tm0)), $(median(Tm0)),$(maximum(Tm0)).")
+
+b̂=[res1[j].α[1]*res1[j].ν[1] for j=1:B]
+α̂ = [res1[j].α[1] for j=1:B]
+
+
+p3=scatter(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate",label=false,title="SuSiE-GLM+correlated covariates")
+p4=scatter(b_1s,α̂, xlabel="True effects",ylabel="PIP",label=false)
+plot(p3,p4,layout=ll)


### PR DESCRIPTION
It is better to report the simulation result quickly as a pull request.

Based on Andrew's implementation including covariates, the result was parallel to his, and only the difference in the implementation is that he simulated random intercept and random covariates (or correlated covariates with predictors) because one of his code options does not include the intercept ( that is why he could draw a random intercept).  The covariates option in my glm as a default is to include the intercept for convenience.  When adding covariates, the inside function combines the intercept with the covariates, so that the intercept is treated as fixed.  Anyway you can find consistence in both results.  glm-susie cannot perform well when covariates are correlated with predictors since glm-susie does not penalize correlated covariates, which is possibly because they treated as fixed terms and maximized in the M-step without the prior.  Instead, regular logistic in R performs better according to his doc.  Thus, it is better to add independent random covariates to glm-susie for analysis.

https://andrewg3311.github.io/susieR_logistic_wflow/VB_susie_logistic_demonstration.html#covariates_correlated_with_predictors

![glm+corrcov](https://user-images.githubusercontent.com/40671409/153664557-729bb747-a6fb-49dc-97b9-d142d0670271.png)
![glm+randcov](https://user-images.githubusercontent.com/40671409/153664575-a32c15ea-9dcb-49e5-9f52-33e9a12c9b9b.png)

