### PR TITLE
check elbo

### DIFF
--- a/src/GLMM.jl
+++ b/src/GLMM.jl
@@ -64,8 +64,8 @@ function initialization(y::Vector{Float64},X::Matrix{Float64},X₀::Union{Matrix
      Xt, Xt₀, yt = rotate(y,X,X₀,T)   
     #  y0= getXy('N',T,y) # rotate w/o centering for β0
     #initialization
-     Σ0= 2*(cov(Xt₀)+I) # avoid sigularity when only with intercept
-     τ0 = 0.001 #rand(1)[1]; #arbitray
+     Σ0= (cov(Xt₀)+I) # avoid sigularity when only with intercept
+     τ0 = 0.1 #rand(1)[1]; #arbitray
     # τ0=1.2   
     # β0 = glm(X₀,y,Binomial()) |> coef
     sig0=getXX('N',Σ0,'T',Xt₀)

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -253,7 +253,7 @@ function mStep!(ξ_new::Vector{Float64},Vg::Matrix{Float64},
    
     
     ξ_new[:]= sqrt.((getXy('N',Xt₀,Badj.β̂)- getXy('N', Badj.M,ghat)+ ghat).^2 
-    + Diagonal(Badj.M*(inv(Badj.λ)-2Vg+BLAS.symm('L','U',Vg,Badj.M))+Vg)*ones(n))
+    + Diagonal(Badj.M*(inv(Badj.λ)-2Vg+BLAS.symm('R','U',Vg,Badj.M)')+Vg)*ones(n))
 
     # tidx =findall(temp.<0.0)
     # if (!isempty(tidx))

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -334,14 +334,17 @@ function ELBO(ξ_new::Vector{Float64},τ2_new::Vector{Float64},Badj::covAdj,ghat
         ghat2::Matrix{Float64},Vg::Matrix{Float64},S::Vector{Float64},
         Xy₀::Vector{Float64},Vβ̂inv::Matrix{Float64},Σ₀::Matrix{Float64},n::Int64)
    
-   
+       
     ll= sum(log.(logistic.(ξ_new))- 0.5*ξ_new+0.5*Lambda.(ξ_new).*ξ_new.^2)
        + Badj.Ŷ'*ghat -0.5*tr(getXX('N',Badj.Λ̂,'N',ghat2))
     lbeta= ELBO(Xy₀,Badj.β̂,Vβ̂inv,Σ₀)   
     # println("τ2_new: $(τ2_new)")
     
     gl = -0.5*(n*log(τ2_new[1])+ sum(log.(S))-logdet(Vg)- 1.0 + tr(ghat2./S)/τ2_new[1]) # g
-    
+    f=open("./test/elbo_components.txt","a")
+    writedlm(f,[ll lbeta gl])
+    close(f)
+
     return ll+gl+lbeta
     
 end
@@ -472,8 +475,8 @@ function emGLMM(yt,Xt₀,S,τ2,ξ,Σ₀;tol::Float64=1e-4)
     # Vβ̂inv,Badj = covarAdj(Xy₀,yt,Xt₀,Σ₀,ξ,n)
    
     crit =1.0; el0=0.0;numitr=1
-      
-    
+    open("./test/elbo_components.txt","w") 
+    #  open("./test/decELBO.txt","w")
     while (crit>=tol)
         ###check again!
          Vβ̂inv,Badj= covarAdj(Xy₀,yt,Xt₀,Σ₀,ξ,n) 
@@ -484,8 +487,13 @@ function emGLMM(yt,Xt₀,S,τ2,ξ,Σ₀;tol::Float64=1e-4)
 
          el1=ELBO(ξ_new,τ2_new,Badj,ghat,ghat2,Vg,S,Xy₀,Vβ̂inv,Σ₀,n)
      
+        #  if(el0>el1)
+        #   f=open("./test/decELBO.txt","a")
+            # writedlm(f,[numitr τ2_new el1 el1-el0])
+        #   close(f)
+        #  end
          crit=abs(el1-el0)
-        #  crit=norm(ξ_new-ξ)+norm(β_new-β)+abs(τ2_new-τ2)+abs(el1-el0)  
+        #  crit=norm(ξ_new-ξ)+norm(τ2_new-τ2)+abs(el1-el0)  
         
          ξ=ξ_new; τ2=τ2_new;el0=el1;βhat=Badj.β̂
         
@@ -524,7 +532,7 @@ function emGLM(L::Int64,y::Vector{Float64},X::Matrix{Float64},X₀::Matrix{Float
     
     crit =1.0; el0=0.0;numitr=1
      
-    
+    open("./test/elbo_glm.txt","w")
     while (crit>=tol)
         ###check again!
         λ= Lambda.(ξ) 
@@ -547,6 +555,9 @@ function emGLM(L::Int64,y::Vector{Float64},X::Matrix{Float64},X₀::Matrix{Float
         
          el1=ELBO(L,ξ_new,β_new,σ0_new,A1,B1,AB2,Sig1,Π,y,X,X₀)
         #  println("elbo = $(el1)")
+         f= open("./test/elbo_glm.txt","a")
+         writedlm(f,[numitr σ0_new el1 el1-el0])
+         close(f)
      
          crit=abs(el1-el0)
          #check later for performance
@@ -558,7 +569,7 @@ function emGLM(L::Int64,y::Vector{Float64},X::Matrix{Float64},X₀::Matrix{Float
         
         
     end
-    
+    println(numitr)
     return ResGLM(ξ,β,σ0,el0,A1, B1, Sig1)
         
 end

--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -113,7 +113,7 @@ Ps=zeros(p,B); Tscore=zeros(p,B);tt=zeros(B);
 #add covariates
 c=3
 
-
+Y0=zeros(n,B);
 # # F =cholesky(K2)
 # # f = svd(F.U)
 # # T,S = f.Vt, f.S.^2
@@ -129,16 +129,17 @@ for j = 1:B
     # g=rand(MvNormal(τ2*K)) #theoretical 91% (intercept)
     g=rand(MvNormal(τ2*K0)) #grm
     # writedlm("./testdata/dataX-julia.csv",X)
-    X₀=randn(n,c)
-    bhat=randn(c)
+    # X₀=randn(n,c)
+    # bhat=randn(c)
     # Y= logistic.(X*b_true+g) .>rand(n) #generating binary outcome
-    # Y= logistic.(X1*b_true+g) .>rand(n)
-    Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n) # random covariates independent of X:95%
+    Y= logistic.(X1*b_true+g) .>rand(n)
+    # Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n) # random covariates independent of X:95%
     Y=convert(Vector{Float64},Y)
     # writedlm("./testdata/dataY-julia.csv",Y)
+    # Y0[:,j]=Y
     t0=@elapsed begin
-        Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
-        # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
+        # Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
+        Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
         T0= computeT(init00,yt,Xt₀,Xt)
     end
    
@@ -150,7 +151,8 @@ for j = 1:B
 #    Ps[:,j]=P0; tt[j]=t0; Tscore[:,j]=Ts
 end
 
-# writedlm("./test/glmm-scoretest.txt",Ps)
+writedlm("./test/y_causal1_1_pop_grm.txt",Y0)
+
 println("min, median, max times for score test are $(minimum(tt)),$(median(tt)), $(maximum(tt)).")
 [init0[j].τ2 for j=1:B]
 sum(Ps[1,:].<0.05)

--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -12,7 +12,7 @@
 ### causal1:pop
 @time info=readdlm(homedir()*"/GIT/SuSiEGLMM.jl/testdata/causal1/pop/ascertained_pop_12_10.bim");
 @time geno=readdlm(homedir()*"/GIT/SuSiEGLMM.jl/testdata/causal1/pop/ascertained_pop_genotype_12_10.txt";header=true);
-@time pheno=readdlm(homedir()*"/GIT/SuSiEGLMM.jl/testdata/causal1/pop/ascertained_pop_phenotype_12_10.txt";header=true); #518 x 4000 snps
+@time pheno=readdlm(homedir()*"/GIT/SuSiEGLMM.jl/testdata/causal1/pop/ascertained_pop_phenotype_12_10.txt";header=true); #503 x 4000 snps
 #data1=readdlm("../testdata/fam_100fams_4000snps.txt";header=true)
 
 # covariate: sex
@@ -126,7 +126,7 @@ for j = 1:B
     b_1s[j] = b_true[1]
     # b_true[1]=b_1s[j]
     # X=randn(n,p)
-    # g=rand(MvNormal(τ2*K)) #theoretical 
+    # g=rand(MvNormal(τ2*K)) #theoretical 91% (intercept)
     g=rand(MvNormal(τ2*K0)) #grm
     # writedlm("./testdata/dataX-julia.csv",X)
     X₀=randn(n,c)
@@ -150,7 +150,7 @@ for j = 1:B
 #    Ps[:,j]=P0; tt[j]=t0; Tscore[:,j]=Ts
 end
 
-writedlm("./test/glmm-scoretest.txt",Ps)
+# writedlm("./test/glmm-scoretest.txt",Ps)
 println("min, median, max times for score test are $(minimum(tt)),$(median(tt)), $(maximum(tt)).")
 [init0[j].τ2 for j=1:B]
 sum(Ps[1,:].<0.05)
@@ -172,14 +172,15 @@ for j = 1:B
    
     Y= logistic.(X1*b_true+g+X₀[2,:].*bhat) .>rand(n) 
     Y=convert(Vector{Float64},Y)
-  
+    t0=@elapsed begin
     Xt, Xt₀, yt,init00= initialization(Y,X2,X₀[2,:],T,S;tol=1e-4)
    
     T0= computeT(init00,yt,Xt₀,Xt)
+    end
     init0=[init0;init00]
     Tscore[:,j]=T0
     Ps[:,j]=ccdf.(Chisq(1),T0)
-
+    tt[j]=t0
 end
 
 #susie-GLMM & glm

--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -100,7 +100,7 @@ X1= (X.-mean(X,dims=2))./std(X,dims=2)
 n,p = size(X1)
  L=1; B=100;τ2=0.1;
 
-#GLMM :scroe test
+#GLMM :score test
 
 # n=100; 
 # p=10; 
@@ -109,85 +109,111 @@ n,p = size(X1)
 b_true=zeros(p);
 b_1s=zeros(B); 
 init0=[]; 
-Ps=zeros(p,B); Tscore=zeros(p,B);tt=zeros(B);
+# Tscore=zeros(p,B);tt=zeros(B); Ps=zeros(p,B); 
+ Tscore1=zeros(p,B);#Ps1=zeros(p,B);
+
+res=[]
 #add covariates
-c=3
+# c=3
 
-Y0=zeros(n,B);
-# # F =cholesky(K2)
-# # f = svd(F.U)
-# # T,S = f.Vt, f.S.^2
-# K0=convert(Matrix{Float64},K0);
-T,S = svdK(K0;LOCO=false)
+# Y0=zeros(n,B);
+K=Matrix(1.0I,n,n)
+T,S = svdK(K;LOCO=false)
+# T,S = svdK(K0;LOCO=false)
 # # H=svd(K2);
-for j = 1:B
 
+for j = 1:B
     b_true[1]= randn(1)[1] 
-    b_1s[j] = b_true[1]
+    b_1s[j] = b_true[1]   
     # b_true[1]=b_1s[j]
-    # X=randn(n,p)
-    # g=rand(MvNormal(τ2*K)) #theoretical 91% (intercept)
-    g=rand(MvNormal(τ2*K0)) #grm
+    X=randn(n,p)
+    g=rand(MvNormal(τ2*K)) #theoretical
+    # g=rand(MvNormal(τ2*K0)) #grm
     # writedlm("./testdata/dataX-julia.csv",X)
     # X₀=randn(n,c)
     # bhat=randn(c)
     # Y= logistic.(X*b_true+g) .>rand(n) #generating binary outcome
-    Y= logistic.(X1*b_true+g) .>rand(n)
+
+    # Y= logistic.(g) .>rand(n)
+    Y1=logistic.(X*b_true+g) .>rand(n)
     # Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n) # random covariates independent of X:95%
-    Y=convert(Vector{Float64},Y)
+    # Y=convert(Vector{Float64},Y)
+    Y1=convert(Vector{Float64},Y1) 
     # writedlm("./testdata/dataY-julia.csv",Y)
     # Y0[:,j]=Y
+    
     t0=@elapsed begin
         # Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
-        Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
-        T0= computeT(init00,yt,Xt₀,Xt)
+        # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
+        # T0= computeT(init00,yt,Xt₀,Xt)
+        Xt, Xt₀, yt,init00= initialization(Y1,X,ones(n,1),T,S;tol=1e-4)
+        T1= computeT(init00,yt,Xt₀,Xt)
     end
-   
     init0=[init0;init00]
-    Tscore[:,j]=T0
-    Ps[:,j]=ccdf.(Chisq(1),T0)
-    tt[j]=t0
+    # Tscore[:,j]=T0;
+    Tscore1[:,j]=T1
+    # # Ps[:,j]=ccdf.(Chisq(1),T0); Ps1[:,j]=ccdf.(Chisq(1),T1)
+    # tt[j]=t0
+    # #glm
+    #  h0= susieGLM(L, ones(p)/p,Y,X1,ones(n,1);tol=1e-4) 
+    #  res=[res;h0]
+    #  h1= susieGLM(L, ones(p)/p,Y1,X1,ones(n,1);tol=1e-5) 
+    #  res=[res;h1]
+    
 #    t0= @elapsed Ts,P0= scoreTest(K0,G,Y,X1;LOCO=false);
 #    Ps[:,j]=P0; tt[j]=t0; Tscore[:,j]=Ts
 end
 
 writedlm("./test/y_causal1_1_pop_grm.txt",Y0)
 
-println("min, median, max times for score test are $(minimum(tt)),$(median(tt)), $(maximum(tt)).")
 [init0[j].τ2 for j=1:B]
+tα=percentile(maximum(Tscore,dims=1)[1,:],95)
+sum(Tscore1[1,:].>tα)
+
 sum(Ps[1,:].<0.05)
+println("min, median, max times for score test are $(minimum(tt)),$(median(tt)), $(maximum(tt)).")
+println("min median max times for glm are $(minimum(Tm)),$(median(Tm)), $(maximum(Tm)).")
 
-# covariates correlated with X : 49%
-X2=copy(X1)
+
+
+#susie-GLMM & glm
+#GLM
+b_true=zeros(p);
+b_1s=zeros(B);
+
+res=[]; #Tm=zeros(B);
+init0=[];Tscore=zeros(p,B)
 for j = 1:B
-
     b_true[1]= randn(1)[1] 
     b_1s[j] = b_true[1]
     # b_true[1]=b_1s[j]
-    # X=randn(n,p)
-    # g=rand(MvNormal(τ2*K)) #theoretical 
-    g=rand(MvNormal(τ2*K0)) #grm
-    # writedlm("./testdata/dataX-julia.csv",X)
-    bhat=randn(1)
-    X₀=rand(MvNormal([1 .9;.9 1]),n)
-    X2[:,1] = X₀[1,:]
-   
-    Y= logistic.(X1*b_true+g+X₀[2,:].*bhat) .>rand(n) 
+    X=randn(n,p)
+    writedlm("./testdata/dataX-julia.csv",X)
+    # g=rand(MvNormal(τ2*K)) 
+    Y= logistic.(X*b_true) .>rand(n) #generating binary outcome
     Y=convert(Vector{Float64},Y)
-    t0=@elapsed begin
-    Xt, Xt₀, yt,init00= initialization(Y,X2,X₀[2,:],T,S;tol=1e-4)
-   
-    T0= computeT(init00,yt,Xt₀,Xt)
-    end
-    init0=[init0;init00]
-    Tscore[:,j]=T0
-    Ps[:,j]=ccdf.(Chisq(1),T0)
-    tt[j]=t0
+    writedlm("./testdata/dataY-julia.csv",Y)
+    res0= susieGLM(L, ones(p)/p,Y,X,ones(n,1);tol=1e-3) 
+#   t0=@elapsed  res0= fineQTL_glm(G,Y,X1;L=L,tol=1e-4)
+    res=[res;res0]; #Tm[j]=t0
+    
+    Xt, Xt₀, yt,init00= initialization(Y,X,ones(n,1),Matrix(1.0I,n,n),ones(n);tol=1e-3)
+        T0= computeT(init00,yt,Xt₀,Xt)
+        init0=[init0;init00]
+        Tscore[:,j]=T0;
 end
 
-#susie-GLMM & glm
+b̂ = [res[2j-1].α[1]*res[2j-1].ν[1] for j=1:B]
+α̂ = [res[2j-1].α[1] for j=1:B]
+writedlm("./test/glm-cau1.txt",[b̂ α̂ b_1s])
+println("min median max times for glm are $(minimum(Tm)),$(median(Tm)), $(maximum(Tm)).")
+
+using UnicodePlots
+scatterplot(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate")
+scatterplot(b_1s,α̂, xlabel="True effects",ylabel="pip")
 
 
+#susie-glmm
 b_true=zeros(p);
 b_1s=zeros(B); 
 rglm=[];rglmm=[];
@@ -253,32 +279,30 @@ Xt, Xt₀, yt, init0 = initialization(y[:,1],X,ones(n,1),T,S;tol=1e-4)
 b̂1 = maximum(res0.α.*res0.ν;dims=2)
 
 
+# # covariates correlated with X (glmm only)
+# X2=copy(X1)
+# for j = 1:B
 
-#GLM
-b_true=zeros(p);
-b_1s=zeros(B);
-
-res=[];Tm=zeros(B);
-
-for j = 1:B
-    # b_true[1]= randn(1)[1] 
-    # b_1s[j] = b_true[1]
-    b_true[1]=b_1s[j]
-    X=randn(n,p)
-    g=rand(MvNormal(τ2*K)) 
-    Y= logistic.(X1*b_true+g) .>rand(n) #generating binary outcome
-    Y=convert(Vector{Float64},Y)
-    # writedlm("./testdata/dataY-julia.csv",Y)
-    # res0= susieGLM(L, ones(p)/p,Y,X,ones(n,1);tol=1e-4) 
-  t0=@elapsed  res0= fineQTL_glm(G,Y,X1;L=L,tol=1e-4)
-    res=[res;res0]; Tm[j]=t0
-end
-
-b̂ = [res[2j-1].α[1]*res[2j-1].ν[1] for j=1:B]
-α̂ = [res[2j-1].α[1] for j=1:B]
-writedlm("./test/glm-cau1.txt",[b̂ α̂ b_1s])
-println("min median max times for glm are $(minimum(Tm)),$(median(Tm)), $(maximum(Tm)).")
-
-using UnicodePlots
-scatterplot(b_1s,b̂,xlabel= "True effects", ylabel="Posterior estimate")
-scatterplot(b_1s,α̂, xlabel="True effects",ylabel="pip")
+#     b_true[1]= randn(1)[1] 
+#     b_1s[j] = b_true[1]
+#     # b_true[1]=b_1s[j]
+#     # X=randn(n,p)
+#     # g=rand(MvNormal(τ2*K)) #theoretical 
+#     g=rand(MvNormal(τ2*K0)) #grm
+#     # writedlm("./testdata/dataX-julia.csv",X)
+#     bhat=randn(1)
+#     X₀=rand(MvNormal([1 .9;.9 1]),n)
+#     X2[:,1] = X₀[1,:]
+   
+#     Y= logistic.(X1*b_true+g+X₀[2,:].*bhat) .>rand(n) 
+#     Y=convert(Vector{Float64},Y)
+#     t0=@elapsed begin
+#     Xt, Xt₀, yt,init00= initialization(Y,X2,X₀[2,:],T,S;tol=1e-4)
+   
+#     T0= computeT(init00,yt,Xt₀,Xt)
+#     end
+#     init0=[init0;init00]
+#     Tscore[:,j]=T0
+#     Ps[:,j]=ccdf.(Chisq(1),T0)
+#     tt[j]=t0
+# end

--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -174,7 +174,9 @@ sum(Ps[1,:].<0.05)
 println("min, median, max times for score test are $(minimum(tt)),$(median(tt)), $(maximum(tt)).")
 println("min median max times for glm are $(minimum(Tm)),$(median(Tm)), $(maximum(Tm)).")
 
-
+#test glm
+Y= readdlm("./testdata/causal1_pop_Y.csv",',';skipstart=1)[:,1]
+res0= susieGLM(L, ones(p)/p,Y,X1,ones(n,1);tol=1e-3) 
 
 #susie-GLMM & glm
 #GLM

--- a/test/causal3.jl
+++ b/test/causal3.jl
@@ -107,7 +107,7 @@ b_true=zeros(p);b_1s=zeros(B);b_2s=zeros(B); b_3s=zeros(B);
  init0=[]; 
 Ps=zeros(p,B); Tscore=zeros(p,B);tt=zeros(B);
 c=10;
-
+Y0= zeros(n,B);
 # F =cholesky(K2)
 # f = svd(F.U)
 # T,S = f.Vt, f.S.^2
@@ -130,13 +130,14 @@ for j = 1:B
     Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n)
     # Y= logistic.(X1*b_true+g) .>rand(n) #generating binary outcome
     Y=convert(Vector{Float64},Y)
+    # Y0[:,j]=Y
     # writedlm("./testdata/dataY-julia.csv",Y)
     t0=@elapsed begin
         # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
         Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
         Ts= computeT(init00,yt,Xt₀,Xt)
     end 
-    
+    # writedlm("./test/y_causal3_1_2_3_fam_grm.txt",Y0)
     init0=[init0;init00]
     Tscore[:,j]=Ts
     Ps[:,j]=ccdf.(Chisq(1),Ts)
@@ -149,8 +150,6 @@ end
 [sum(Ps[j,:].<0.05) for j=1:L] # 83 81 73% for theoretical, 97 97 85% for grm :intercept only
 # 96 95 86% for grm+random covariates (c=10) median= 1.230s 
 
-
-# writedlm("./test/glmm-scoretest.txt",Ps)
 println("min, median, max times for score test are $(minimum(tt)), $(median(tt)),$(maximum(tt)).")
 
 
@@ -177,7 +176,7 @@ t=@elapsed begin
     Ts= computeT(init00,yt,Xt₀,Xt)
 end 
 P=ccdf.(Chisq(1),Ts)
-# P[[2 3 306 782 1660]]
+P[[2 3 306 782 1660]]
 #  4.7232e-33  0.00382837  4.7232e-33  0.00382837  2.81394e-19
 
 #for thoeretical K

--- a/test/causal3.jl
+++ b/test/causal3.jl
@@ -171,7 +171,7 @@ g=rand(MvNormal(τ2*K0))
 Y= logistic.(X2*b_true+g) .>rand(n)
     # Y= logistic.(X1*b_true+g) .>rand(n) #generating binary outcome
 Y=convert(Vector{Float64},Y)
-@time begin
+t=@elapsed begin
     # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
     Xt, Xt₀, yt,init00= initialization(Y,X2,ones(n,1),T,S;tol=1e-4)
     Ts= computeT(init00,yt,Xt₀,Xt)


### PR DESCRIPTION
I have checked elbo in glmm as well as glm in Julia and R.  glmm with more reduced tolerance (1e-5~9) shows that elbo increases but very slow to converge after a few iterations of hovering between + and - of the difference between two consecutive elbos, which is because an initial value of elbo before starting into 'while' loop set to be 1.   Then I decomposed elbos into three pieces and saved them for each iteration: El_c  (1st line in (78) in overleaf),  terms for integrating out \beta (2nd line in (78)), and KL for g (3rd line in (78)).  \beta part decreases, but the other two increase.   Can you ask Peter about \hat{D} if you have not done while I check the derivation of integrating \beta out  again?

Another thing I found out from julia-glm is that it seems to converge fast but it is hovering around the solution to the parameters after fast reaching them.  ELBO^(t)-ELBO(t-1) increases quickly and then decreases a bit although the results are pretty consistent with ones by Andrew's code.  His elbo stays the same value after reaching the solution.  I guess he made some trick in the code to stay there.  His code includes more conditions, but I did not get it.  I will take a close look at his code again to see if I can do in my code for stability for the glm version.