### PR TITLE
correcting to symmetric matrices

### DIFF
--- a/src/GLMM.jl
+++ b/src/GLMM.jl
@@ -65,7 +65,7 @@ function initialization(y::Vector{Float64},X::Matrix{Float64},X₀::Union{Matrix
     #  y0= getXy('N',T,y) # rotate w/o centering for β0
     #initialization
      Σ0= 2(cov(Xt₀)+I) # avoid sigularity when only with intercept
-     τ0 = 0.01 #rand(1)[1]; #arbitray
+     τ0 = 0.1 #rand(1)[1]; #arbitray
     # τ0=1.2   
     # β0 = glm(X₀,y,Binomial()) |> coef
     sig0=getXX('N',Σ0,'T',Xt₀)

--- a/src/SuSiEGLM.jl
+++ b/src/SuSiEGLM.jl
@@ -3,9 +3,9 @@
 export susieGLM, fineQTL_glm
 using GLM
 
-function susieGLM(L::Int64,Π::Vector{Float64},y::Vector{Float64},X::Matrix{Float64},X₀::Union{Matrix{Float64},Vector{Float64}};tol=1e-4)
+function susieGLM(n::Int64,L::Int64,Π::Vector{Float64},y::Vector{Float64},X::Matrix{Float64},X₀::Union{Matrix{Float64},Vector{Float64}};tol=1e-4)
   
-    n =size(X₀,1)
+    # n =size(X,1)
     y1= zeros(n)
   
     if(X₀!= ones(n,1)) #&&(size(X₀,2)>1)
@@ -70,20 +70,20 @@ Performs SuSiE (Sum of Single Effects model) GLM fine-mapping analysis for a bin
 function fineQTL_glm(G::GenoInfo,y::Vector{Float64},X::Matrix{Float64},
     X₀::Union{Matrix{Float64},Vector{Float64}}=ones(length(y),1);L::Int64=10,Π::Vector{Float64}=[1/size(X,2)],tol=1e-4)
 
-    Chr=sort(unique(G.chr));
+    Chr=sort(unique(G.chr)); n, p=size(X)
     est= @distributed (vcat) for j= eachindex(Chr)
                  midx= findall(G.chr.== Chr[j])
                   #check size of Π
-                  if (Π==[1/size(X,2)]) #default value
+                  if (Π==[1/p]) #default value
                     m=length(midx)
                     Π1 =ones(m)/m #adjusting πⱼ
-                   elseif (length(Π)!= size(X,2))
-                      println("Error. The length of Π should match $(size(X,2)) SNPs!")
+                   elseif (length(Π)!= p)
+                      println("Error. The length of Π should match $(p) SNPs!")
                    else
                     Π1 = Π[midx]
                  end
 
-                 est0= susieGLM(L,Π1,y,X[:,midx],X₀;tol=tol)
+                 est0= susieGLM(n,L,Π1,y,X[:,midx],X₀;tol=tol)
                         est0
     end
 


### PR DESCRIPTION
First I have generated 100 simulated data each with the theoretical grm and  one with the empirical grm and have tracked each component of elbo after correcting the inverse of var(g) while changing the initial value of \tau^2.  (previously quickly checked with the theoretical grm). Too small initial values (\tau^2 less than two decimal values) converge quickly, which does not seem to be good.  Small simulation study with the theoretical grm looks ok in terms of estimation and about 71 % power (this time, tried to correct type I error by better way). i.e. for each replicate, picked up the max test statistic from the null data and got the cutoff at 95% although 100 simulations were small.  Used the cutoff to compute the proportion of test statistics of the H1 data greater than that.   

Still simulation by the empirical grm  is not good; depending on the data set generated, elbo starts to increase after long hovering b/w +/-.  After discussing with my colleague, Gregory, I have tried to force some of matrix multiplication which are supposedly theoretically symmetric to be symmetric since Julia cannot recognize symmetriness unlike R. I will test them between R and Julia for glm with the same data to track all values up to elbos and look into glmm too. 