### PR TITLE
update and test old glmm 

### DIFF
--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -128,42 +128,36 @@ for j = 1:B
     b_1s[j] = b_true[1]   
     # b_true[1]=b_1s[j]
     # X=randn(n,p)
-    g=rand(MvNormal(τ2*K0)) #theoretical
-    # g=rand(MvNormal(τ2*K0)) #grm
+    # g=rand(MvNormal(τ2*K)) #theoretical
+    g=rand(MvNormal(τ2*K0)) #grm
     # writedlm("./testdata/dataX-julia.csv",X)
     # X₀=randn(n,c)
     # bhat=randn(c)
     # Y= logistic.(X*b_true+g) .>rand(n) #generating binary outcome
 
-    Y= logistic.(g) .>rand(n)
+    # Y= logistic.(g) .>rand(n)
     Y1=logistic.(X1*b_true+g) .>rand(n)
     # Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n) # random covariates independent of X:95%
-    Y=convert(Vector{Float64},Y)
+    # Y=convert(Vector{Float64},Y)
     Y1=convert(Vector{Float64},Y1) 
     # writedlm("./testdata/dataY-julia.csv",Y)
-    Y0[:,j]=Y1
+    # Y0[:,j]=Y1
     
     t0=@elapsed begin
         # Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
-        Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
-        T0= computeT(init00,yt,Xt₀,Xt)
+        # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
+        # T0= computeT(init00,yt,Xt₀,Xt)
         # Xt, Xt₀, yt,init01= initialization(Y1,X1,ones(n,1),T,S;tol=1e-3)
         # T1= computeT(init01,yt,Xt₀,Xt)
+        res0= susieGLMM(L,ones(p)/p,Y1,X1,ones(n,1),T,S;tol=1e-3)
     end
-    init0=[init0;init00]
+    # init0=[init0;init00]
     # init1=[init1;init01]
-    Ts[:,j]=T0;
+    # Ts[:,j]=T0;
     # Ts1[:,j]=T1
     # # Ps[:,j]=ccdf.(Chisq(1),T0); Ps1[:,j]=ccdf.(Chisq(1),T1)
     # tt[j]=t0
-    # #glm
-    #  h0= susieGLM(L, ones(p)/p,Y,X1,ones(n,1);tol=1e-4) 
-    #  res=[res;h0]
-    #  h1= susieGLM(L, ones(p)/p,Y1,X1,ones(n,1);tol=1e-5) 
-    #  res=[res;h1]
-    
-#    t0= @elapsed Ts,P0= scoreTest(K0,G,Y,X1;LOCO=false);
-#    Ps[:,j]=P0; tt[j]=t0; Tscore[:,j]=Ts
+    res=[res;res0]
 end
 
 # writedlm("./test/y_causal1_1_pop_grm.txt",Y0)
@@ -188,6 +182,7 @@ println("min median max times for glm are $(minimum(Tm)),$(median(Tm)), $(maximu
 #test glm
 Y= readdlm("./testdata/causal1_pop_Y.csv",',';skipstart=1)[:,1]
 res0= susieGLM(L, ones(p)/p,Y,X1,ones(n,1);tol=1e-3) 
+
 
 #susie-GLMM & glm
 #GLM
@@ -215,6 +210,9 @@ for j = 1:B
         init0=[init0;init00]
         Tscore[:,j]=T0;
 end
+
+
+
 
 b̂ = [res[2j-1].α[1]*res[2j-1].ν[1] for j=1:B]
 α̂ = [res[2j-1].α[1] for j=1:B]

--- a/test/causal1.jl
+++ b/test/causal1.jl
@@ -128,17 +128,17 @@ for j = 1:B
     b_1s[j] = b_true[1]   
     # b_true[1]=b_1s[j]
     # X=randn(n,p)
-    # g=rand(MvNormal(τ2*K)) #theoretical
-    g=rand(MvNormal(τ2*K0)) #grm
+    g=rand(MvNormal(τ2*K0)) #theoretical
+    # g=rand(MvNormal(τ2*K0)) #grm
     # writedlm("./testdata/dataX-julia.csv",X)
     # X₀=randn(n,c)
     # bhat=randn(c)
     # Y= logistic.(X*b_true+g) .>rand(n) #generating binary outcome
 
-    # Y= logistic.(g) .>rand(n)
+    Y= logistic.(g) .>rand(n)
     Y1=logistic.(X1*b_true+g) .>rand(n)
     # Y= logistic.(X1*b_true+g+X₀*bhat) .>rand(n) # random covariates independent of X:95%
-    # Y=convert(Vector{Float64},Y)
+    Y=convert(Vector{Float64},Y)
     Y1=convert(Vector{Float64},Y1) 
     # writedlm("./testdata/dataY-julia.csv",Y)
     # Y0[:,j]=Y1
@@ -146,23 +146,30 @@ for j = 1:B
     t0=@elapsed begin
         # Xt, Xt₀, yt,init00= initialization(Y,X1,X₀,T,S;tol=1e-4)
         # Xt, Xt₀, yt,init00= initialization(Y,X1,ones(n,1),T,S;tol=1e-4)
-        # T0= computeT(init00,yt,Xt₀,Xt)
+ 
         # Xt, Xt₀, yt,init01= initialization(Y1,X1,ones(n,1),T,S;tol=1e-3)
-        # T1= computeT(init01,yt,Xt₀,Xt)
-        res0= susieGLMM(L,ones(p)/p,Y1,X1,ones(n,1),T,S;tol=1e-3)
+        
+        # res= susieGLM(n,L, ones(p)/p,Y1,X1,ones(n,1);tol=1e-3) 
+        # res0= susieGLMM(L,ones(p)/p,Y1,X1,ones(n,1),T,S;tol=1e-3)
+        Xt, Xt₀, yt,init10=gLMM(Y1,X1,ones(n,1),T,S;tol=1e-4)
+        Xt, Xt₀, yt,init00=gLMM(Y,X1,ones(n,1),T,S;tol=1e-4)
+        T1= computeT(init10,yt,Xt₀,Xt)
+        T0= computeT(init00,yt,Xt₀,Xt)
+       
+        # Xt, Xt₀, yt,init=initialization(Y1,X1,ones(n,1),T,S;tol=1e-4)
     end
-    # init0=[init0;init00]
-    # init1=[init1;init01]
-    # Ts[:,j]=T0;
-    # Ts1[:,j]=T1
+    init0=[init0;init00]
+    init1=[init1;init10]
+    Ts[:,j]=T0;
+    Ts1[:,j]=T1
     # # Ps[:,j]=ccdf.(Chisq(1),T0); Ps1[:,j]=ccdf.(Chisq(1),T1)
     # tt[j]=t0
-    res=[res;res0]
+    # res=[res;res0]
 end
 
 # writedlm("./test/y_causal1_1_pop_grm.txt",Y0)
 for j=1:B
-    Xt, Xt₀, yt,init01= initialization(Y0[:,j],X1,ones(n,1),T,S;tol=1e-4)
+    Xt, Xt₀, yt,init01= initialization(Y,X,ones(n,1),Matrix(1.0I,n,n),ones(n);tol=1e-4)
     T1= computeT(init01,yt,Xt₀,Xt)
     # Xt, Xt₀, yt,init01= initialization(Y1,X1,ones(n,1),T,S;tol=1e-3)
     # T1= computeT(init01,yt,Xt₀,Xt)


### PR DESCRIPTION
I updated old glmm based on susie-glm & glmm and tested with the new version (integrated out version).   You can easily guess that susie-glm and -glmm yield similar values and so do both glmm's although the new glmm needs to fix elbo decrement. 
 I also tested small simulation generated by Tianyi's grm data for the updated old glmm.  All three final values of \tau^2 of susie-glmm, glmm's do not move further from the initial values( I set all the same).  Also, the old fixed glmm still gives domain error when estimating simulation data sets generated by the grm.  I observed both old susie- glmm and glmm yielded inf \tau^2 when their initials are 0.1 and the true is 0.4.  The integrated out version give a finite value but inaccurate, which just printed the similar initial value.  Adding random g (var=\tau^2 K) does not seem to make the loglik function convex but almost flat although prior probability acts as penalization.  I will think about how to fix while working on the new glmm version.