### PR TITLE
Writing EM functions adding snp effect

### DIFF
--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -138,7 +138,7 @@ function symXX(t::Char,X::Array{Float64,2})
     
    XtX = Symmetric(BLAS.syrk('U',t,1.0,X))
     
-    return XtX
+    return convert(Matrix{Float64},XtX)
     
 end
 

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -10,7 +10,7 @@
 
 # using Statistics, LinearAlgebra, Random, StatsBase, Distributions, Distributed
 
-
+## integration out version based on Peter's derivation
 
 
 export covarAdj, postG!, emG!, postB!,emB,mStep!,ELBO,emGLMM,emGLM, Result, Approx0, ResGLM

--- a/test/debug_glmm1.ipynb
+++ b/test/debug_glmm1.ipynb
@@ -5973,7 +5973,8 @@
     "    \n",
     "    Y0[:,j]=rand.(Bernoulli.(p0)) #H0 data\n",
     "    Y1[:,j]=rand.(Bernoulli.(p1)) #H1 data\n",
-    "    \n",
+    "    # similarily :\n",
+    "#     Y[:,j] = collect(Iterators.flatten(rand.(Bernoulli.(p1), 1))) \n",
     "    # Y0[:,j]=Y1\n",
     "# test power\n",
     "#     t0=@elapsed begin\n",
@@ -6101,7 +6102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 76,
    "id": "58528619-0cba-4f21-aa05-e9c9bc73f9ec",
    "metadata": {},
    "outputs": [
@@ -6111,13 +6112,13 @@
        "0.0"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "minimum(Pt0.*(1.0.-Pt0))"
+    "minimum(P1.*(1.0.-P1))"
    ]
   },
   {
@@ -6211,6 +6212,53 @@
    "source": [
     "tt=copy(Tt)\n",
     "ccdf.(Chisq(1),tt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "7264e8bd-cdaa-4656-9a76-b35e61668d4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "503×200 Matrix{Float64}:\n",
+       " 0.751217  0.527388  0.500791  0.519309  …  0.507803  0.508977  0.501047\n",
+       " 0.533663  0.508527  0.500103  0.516021     0.592522  0.500362  0.507813\n",
+       " 0.553931  0.561353  0.502828  0.590298     0.500291  0.500385  0.513134\n",
+       " 0.531108  0.500011  0.560871  0.505685     0.700454  0.534789  0.513062\n",
+       " 0.550194  0.502617  0.50005   0.553008     0.508706  0.543345  0.501972\n",
+       " 0.500973  0.533799  0.541063  0.516457  …  0.50973   0.567661  0.532102\n",
+       " 0.503     0.581854  0.59169   0.505422     0.552913  0.625994  0.504578\n",
+       " 0.55108   0.554201  0.502308  0.563396     0.501574  0.60853   0.501702\n",
+       " 0.525205  0.501592  0.508936  0.510774     0.507444  0.658141  0.509333\n",
+       " 0.520622  0.514431  0.501297  0.52954      0.515701  0.553912  0.570407\n",
+       " 0.518784  0.50001   0.500375  0.508263  …  0.511677  0.500539  0.523362\n",
+       " 0.540335  0.525474  0.528003  0.500635     0.501223  0.605121  0.531402\n",
+       " 0.596471  0.513267  0.51152   0.503139     0.507935  0.51822   0.529983\n",
+       " ⋮                                       ⋱                      \n",
+       " 0.544582  0.518578  0.511945  0.545955     0.500181  0.513134  0.500776\n",
+       " 0.56349   0.500269  0.500009  0.513127     0.511307  0.504881  0.517422\n",
+       " 0.500008  0.512377  0.500436  0.501467     0.501761  0.50987   0.500001\n",
+       " 0.511776  0.508483  0.500007  0.53406      0.505735  0.531448  0.511155\n",
+       " 0.506975  0.50028   0.500074  0.503101  …  0.512392  0.501498  0.503588\n",
+       " 0.505773  0.501976  0.505401  0.500335     0.500457  0.511235  0.500009\n",
+       " 0.511632  0.500116  0.500488  0.500096     0.501293  0.502102  0.513081\n",
+       " 0.50063   0.510388  0.503165  0.531777     0.503246  0.501819  0.506048\n",
+       " 0.501027  0.506987  0.502999  0.505492     0.501714  0.500411  0.502322\n",
+       " 0.520698  0.523261  0.500014  0.50777   …  0.500365  0.513721  0.503345\n",
+       " 0.504973  0.503411  0.50045   0.501783     0.500199  0.525231  0.50394\n",
+       " 1.0       1.0       0.772886  0.999991     0.501427  0.69165   0.992732"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Pt1"
    ]
   },
   {
@@ -7637,35 +7685,108 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 120,
    "id": "b6cba7a6-29bb-46fd-9f34-43b9603d4f0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writedlm(\"Seed12_Y0.txt\",Y0)\n",
+    "writedlm(\"Seed12_Y1.txt\",Y1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "ef4320de-a287-4e88-b4dd-e385995e5607",
    "metadata": {},
    "outputs": [
     {
-     "ename": "LoadError",
-     "evalue": "UndefVarError: a not defined",
-     "output_type": "error",
-     "traceback": [
-      "UndefVarError: a not defined",
-      "",
-      "Stacktrace:",
-      " [1] top-level scope",
-      "   @ :0",
-      " [2] eval",
-      "   @ ./boot.jl:360 [inlined]",
-      " [3] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)",
-      "   @ Base ./loading.jl:1116"
-     ]
+     "data": {
+      "text/plain": [
+       "0.06241067363133824"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "a"
+    "init0[2].τ2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "id": "7ea8e857-ae16-40fd-ad55-2df9912344b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1×2 Matrix{Float64}:\n",
+       " -603.274  -612.223"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Β=[init0[1].elbo init1[1].elbo]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "id": "91179502-1681-4d58-9f36-8a8db3c74aa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for j=2:B\n",
+    "   Β0=[init0[j].elbo init1[j].elbo]\n",
+    "    Β=[Β;Β0]\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "id": "3c4fb7a7-afcb-4889-8ad5-1f98ba69fd2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writedlm(\"Seed12_elbo_0_1est.txt\",Β)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "id": "acc128b5-988b-498c-ba4f-ad98bf3b23f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Η= init0[1].ξ\n",
+    "for j=2:B\n",
+    "    Η = [Η init0[j].ξ]\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "id": "b96f3607-3f87-46fe-8203-f20a26043bf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writedlm(\"Seed12_xi0est.txt\",Η)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef4320de-a287-4e88-b4dd-e385995e5607",
+   "id": "2854649d-1c1b-4aac-a25f-015e4c0248ef",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
I have written emAlt and relevant functions that add a snp effect ( b~N(0,\sigma0)), will add the upper level function for the emAlt, and will work with simulation data prepared by Tianyi after debugging functions for correction if exists.  