### PR TITLE
debugging score test for type 1 error inflation

### DIFF
--- a/src/GLMM.jl
+++ b/src/GLMM.jl
@@ -195,11 +195,13 @@ function Projector!(P₁::Matrix{Float64},W⁻::Vector{Float64},Xt₀::Matrix{Fl
 
 end
 
-function Bern_est!(p̂::Vector{Float64},W⁻::Vector{Float64},y::Vector{Float64},X₀::Matrix{Float64},T::Matrix{Float64},init0::Approx0)
-
+# function Bern_est!(p̂::Vector{Float64},W⁻::Vector{Float64},y::Vector{Float64},X₀::Matrix{Float64},T::Matrix{Float64},init0::Approx0)
+function Bern_est!(p̂::Vector{Float64},W⁻::Vector{Float64},init0::Approx0)
      # Bernoulli estimates
-     p̂[:] =  (2y.-1.0).*(getXy('N',X₀,init0.β)+getXy('T',T,init0.μ))  #non-tranformed centered y
-     p̂[:] = logistic.(p̂)
+    #  p̂[:] =  (2y.-1.0).*(getXy('N',X₀,init0.β)+getXy('T',T,init0.μ))  #non-tranformed centered y
+    #  p̂[:] = logistic.(init0.ξ).*exp.(0.5(p̂- init0.ξ))-Lambda.(init0.ξ).*(p̂.^2-init0.ξ.^2)
+    #  p̂[:] = exp.(p̂)
+    p̂[:] = logistic.(init0.ξ)
      W⁻[:]  = 1.0./(p̂.*(1.0.-p̂)) #invW
 
 end
@@ -248,7 +250,8 @@ function testStats(init0::Approx0,y::Vector{Float64},X::Matrix{Float64},Xt::Matr
     Scr=zeros(p); Vˢ=zeros(p,p)
    
 
-      Bern_est!(p̂,W⁻,y,X₀,T,init0)
+    #   Bern_est!(p̂,W⁻,y,X₀,T,init0)
+      Bern_est!(p̂,W⁻,init0)
       Projector!(P₁,W⁻,Xt₀,S,init0.τ2[1])
       mScore!(Scr,X,y,p̂)
       mScoreVar!(Vˢ,Xt,P₁)


### PR DESCRIPTION
I examined the formula again and modified predicted value of y as in (12) in main2.tex.  I tried using h(\xi) only as an optimal lower bound since x^2=\xi^2 in the M-step derivation, dropping the quadratic terms due to the same reason,i.e. h(\xi)exp(0.5(x-xi)), and using all terms in the lower bound.  I then pick up extreme case that gives too small p-value in Type I error estimation, and looked into it comparing with the other cases.  Definitely the second case is wrong since \hat{y} includes too large values in the extreme case if you look at the debug_susieglmm notebook, as well as computing the projector throws a domain error.  Using optimal xi for predicted y reduces the inflation a bit but still needs to work more.  This seems from very large \xi in one entry, which yields probability 1 -> var 0.  When talking to Saunak showing the histogram, he  diagnosed that the reference distribution might be off, which means in some situations, the distribution is the mixture of chi^2 and point mass at 0.  This makes sense to me, too.   There may be some remedy to take care of this.  I think I have seen this some papers. You can give me any literature about this when we discuss this.